### PR TITLE
[feat] textstyle 위젯 분리

### DIFF
--- a/lyc_flutter_project/lib/screens/join_membership_screen_1.dart
+++ b/lyc_flutter_project/lib/screens/join_membership_screen_1.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lyc_flutter_project/data/app_color.dart';
 import 'package:lyc_flutter_project/screens/join_membership_screen_2.dart';
+import 'package:lyc_flutter_project/widget/AppTextStyles.dart';
 
 import '../widget/normal_appbar.dart';
 
@@ -9,51 +10,13 @@ class JoinMembershipScreen1 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 공통 TextStyle
-    TextStyle titleTextStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 20,
-      letterSpacing: -0.1,
-      color: Colors.white,
-    );
-
-    TextStyle labelTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: Color(0xFF000000),
-    );
-
-    TextStyle hintTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: Color(0xFF8D8D8D),
-    );
-
-    TextStyle littleTitleStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 16,
-      height: 1.1,
-      letterSpacing: -0.1,
-      color: Colors.black,
-    );
-
-    TextStyle otherLoginTextStyle = TextStyle(
-      fontWeight: FontWeight.w400,
-      fontSize: 12,
-      color: Colors.black,
-    );
-
     return Scaffold(
       backgroundColor: AppColor.lightGrey,
-      appBar:  NormalAppbar(
-      backButton: true,
-      title: "회원가입",
-      deleteButton: false,
-    ),
+      appBar: NormalAppbar(
+        backButton: true,
+        title: "회원가입",
+        deleteButton: false,
+      ),
       body: Center(
         child: SingleChildScrollView(
           child: Column(
@@ -77,48 +40,58 @@ class JoinMembershipScreen1 extends StatelessWidget {
                       alignment: Alignment.topLeft,
                       child: Text(
                         'Step 1. 아이디 패스워드 설정',
-                        style: littleTitleStyle,
+                        style: AppTextStyles.littleTitle,
                       ),
                     ),
                     buildInputField(
-                        '이름', '이름을 입력해주세요', labelTextStyle, hintTextStyle),
+                        '이름',
+                        '이름을 입력해주세요',
+                        AppTextStyles.labelTextStyle,
+                        AppTextStyles.hint
+                    ),
                     buildInputField(
-                        '아이디', '아이디를 입력해주세요', labelTextStyle, hintTextStyle),
+                        '아이디',
+                        '아이디를 입력해주세요',
+                        AppTextStyles.labelTextStyle,
+                        AppTextStyles.hint
+                    ),
                     buildInputField(
-                        '이메일', '이메일을 입력해주세요', labelTextStyle, hintTextStyle),
+                        '이메일',
+                        '이메일을 입력해주세요',
+                        AppTextStyles.labelTextStyle,
+                        AppTextStyles.hint
+                    ),
                     buildInputField(
-                        '패스워드', '패스워드를 입력해주세요', labelTextStyle, hintTextStyle),
+                        '패스워드',
+                        '패스워드를 입력해주세요',
+                        AppTextStyles.labelTextStyle,
+                        AppTextStyles.hint
+                    ),
                     buildInputField(
-                        '패스워드 확인', '패스워드를 다시 입력해주세요', labelTextStyle, hintTextStyle),
+                        '패스워드 확인',
+                        '패스워드를 다시 입력해주세요',
+                        AppTextStyles.labelTextStyle,
+                        AppTextStyles.hint
+                    ),
                     TextButton(
                       onPressed: () {
                         Navigator.push(
                           context,
-                          MaterialPageRoute(builder: (context) => JoinMembershipScreen2()),
+                          MaterialPageRoute(builder: (context) => const JoinMembershipScreen2()),
                         );
                       },
-                      style: ButtonStyle(
-                        backgroundColor: MaterialStateProperty.all(AppColor.beige),
-                        shape: MaterialStateProperty.all(
-                          RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(20),
-                          ),
+                      style: TextButton.styleFrom(
+                        backgroundColor: AppColor.beige,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20),
                         ),
-                        padding: WidgetStateProperty.all(
-                          EdgeInsets.symmetric(vertical: 11),
-                        ),
+                        padding: EdgeInsets.symmetric(vertical: 11),
                       ),
                       child: SizedBox(
                         width: 230,
                         child: Text(
                           '다음',
-                          style: TextStyle(
-                            fontWeight: FontWeight.w700,
-                            fontSize: 14,
-                            height: 1.3,
-                            letterSpacing: -0.1,
-                            color: Colors.white,
-                          ),
+                          style: AppTextStyles.button,
                           textAlign: TextAlign.center,
                         ),
                       ),
@@ -133,7 +106,7 @@ class JoinMembershipScreen1 extends StatelessWidget {
                 },
                 child: Text(
                   '다른 계정으로 회원가입',
-                  style: otherLoginTextStyle,
+                  style: AppTextStyles.otherLoginTextStyle,
                 ),
               ),
               SizedBox(

--- a/lyc_flutter_project/lib/screens/join_membership_screen_2.dart
+++ b/lyc_flutter_project/lib/screens/join_membership_screen_2.dart
@@ -1,48 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:lyc_flutter_project/data/app_color.dart';
 import 'package:lyc_flutter_project/widget/normal_appbar.dart';
 import 'package:lyc_flutter_project/screens/join_membership_screen_1.dart';
 import 'package:lyc_flutter_project/screens/join_membership_screen_3.dart';
+import '../widget/AppTextStyles.dart';
 
 class JoinMembershipScreen2 extends StatelessWidget {
   const JoinMembershipScreen2({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // 공통 TextStyle
-    TextStyle titleTextStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 20,
-      letterSpacing: -0.1,
-      color: Colors.white,
-    );
-
-    TextStyle hintTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: Color(0xFF8D8D8D),
-    );
-
-    TextStyle littleTitleStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 16,
-      height: 1.1,
-      letterSpacing: -0.1,
-      color: Colors.black,
-    );
-
-    TextStyle buttonTextStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 14,
-      height: 1.3,
-      letterSpacing: -0.1,
-      color: Colors.white,
-    );
-
     return Scaffold(
-      backgroundColor: Color(0xFFF1F1F1),
+      backgroundColor: AppColor.lightGrey,
       appBar: NormalAppbar(
         backButton: true,
         title: "회원가입",
@@ -70,7 +40,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                       alignment: Alignment.topLeft,
                       child: Text(
                         'Step 2. 회원정보 입력',
-                        style: littleTitleStyle,
+                        style: AppTextStyles.littleTitle,
                       ),
                     ),
                     Container(
@@ -93,7 +63,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                     // '닉네임' TextField
                     Container(
                       decoration: BoxDecoration(
-                        color: Color(0xFFF1F1F1),
+                        color:AppColor.lightGrey,
                         borderRadius: BorderRadius.circular(20),
                       ),
                       width: 252,
@@ -101,7 +71,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                       child: TextField(
                         decoration: InputDecoration(
                           hintText: '닉네임',
-                          hintStyle: hintTextStyle,
+                          hintStyle: AppTextStyles.hint,
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(20),
                             borderSide: BorderSide.none,
@@ -114,7 +84,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                     // '자유롭게 자신을 소개해주세요' TextField
                     Container(
                       decoration: BoxDecoration(
-                        color: Color(0xFFF1F1F1),
+                        color: AppColor.lightGrey,
                         borderRadius: BorderRadius.circular(20),
                       ),
                       width: 252, // 너비를 252로 설정
@@ -122,7 +92,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                         maxLines: 3, // 여러 줄 입력 가능
                         decoration: InputDecoration(
                           hintText: '자유롭게 자신을 소개해 주세요',
-                          hintStyle: hintTextStyle,
+                          hintStyle: AppTextStyles.hint,
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(20),
                             borderSide: BorderSide.none,
@@ -150,7 +120,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                       );
                     },
                     style: TextButton.styleFrom(
-                      backgroundColor: Color(0xFFD9D9D9),
+                      backgroundColor: AppColor.grey,
                       minimumSize: Size(120, 40), // 버튼 크기 설정
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(20),
@@ -158,8 +128,8 @@ class JoinMembershipScreen2 extends StatelessWidget {
                     ),
                     child: Text(
                       '이전',
-                      style: hintTextStyle.copyWith(
-                        color: Color(0xFF000000),
+                      style: AppTextStyles.hint.copyWith(
+                        color: Colors.black,
                         fontSize: 14,
                       ),
                     ),
@@ -173,7 +143,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                       );
                     },
                     style: TextButton.styleFrom(
-                      backgroundColor: Color(0xFFC4BAA2),
+                      backgroundColor: AppColor.beige,
                       minimumSize: Size(120, 40), // 버튼 크기 설정
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(20),
@@ -181,7 +151,7 @@ class JoinMembershipScreen2 extends StatelessWidget {
                     ),
                     child: Text(
                       '다음',
-                      style: buttonTextStyle,
+                      style: AppTextStyles.button,
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lyc_flutter_project/lib/screens/join_membership_screen_3.dart
+++ b/lyc_flutter_project/lib/screens/join_membership_screen_3.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lyc_flutter_project/widget/AppTextStyles.dart';
 import 'package:lyc_flutter_project/widget/normal_appbar.dart';
 import 'package:lyc_flutter_project/screens/join_membership_screen_2.dart';
 import 'package:lyc_flutter_project/data/app_color.dart';
@@ -8,37 +9,6 @@ class JoinMembershipScreen3 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 공통 TextStyle
-    TextStyle titleTextStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 20,
-      letterSpacing: -0.1,
-      color: Colors.white,
-    );
-
-    TextStyle hintTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: AppColor.deepGrey, // grey로 변경
-    );
-
-    TextStyle littleTitleStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 16,
-      height: 1.1,
-      letterSpacing: -0.1,
-      color: Colors.black, // 검은색으로 유지
-    );
-
-    TextStyle buttonTextStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 14,
-      height: 1.3,
-      letterSpacing: -0.1,
-      color: Colors.white,
-    );
 
     return Scaffold(
       backgroundColor: AppColor.lightGrey, // 배경색 변경
@@ -68,14 +38,14 @@ class JoinMembershipScreen3 extends StatelessWidget {
                       padding: EdgeInsets.fromLTRB(7, 0, 7, 8), // 아래쪽 여백을 줄였습니다
                       child: Text(
                         'Step 3. 배송지 입력',
-                        style: littleTitleStyle,
+                        style: AppTextStyles.littleTitle,
                       ),
                     ),
                     Padding(
                       padding: EdgeInsets.fromLTRB(13.7, 0, 13.7, 25), // 위쪽 여백을 줄였습니다
                       child: Text(
                         '배송지 정보는 다른 사용자에게 노출되지 않습니다.',
-                        style: hintTextStyle,
+                        style: AppTextStyles.hint,
                       ),
                     ),
                     // 우편번호 입력 필드 및 버튼
@@ -94,7 +64,7 @@ class JoinMembershipScreen3 extends StatelessWidget {
                                 decoration: InputDecoration(
                                   border: InputBorder.none,
                                   hintText: '우편번호',
-                                  hintStyle: hintTextStyle,
+                                  hintStyle: AppTextStyles.hint,
                                   contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12), // 중앙 정렬
                                 ),
                                 textAlignVertical: TextAlignVertical.center, // 텍스트 수직 중앙 정렬
@@ -144,7 +114,7 @@ class JoinMembershipScreen3 extends StatelessWidget {
                           decoration: InputDecoration(
                             border: InputBorder.none,
                             hintText: '주소',
-                            hintStyle: hintTextStyle,
+                            hintStyle: AppTextStyles.hint,
                             contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12), // 중앙 정렬
                           ),
                           textAlignVertical: TextAlignVertical.center, // 텍스트 수직 중앙 정렬
@@ -165,7 +135,7 @@ class JoinMembershipScreen3 extends StatelessWidget {
                           decoration: InputDecoration(
                             border: InputBorder.none,
                             hintText: '상세주소',
-                            hintStyle: hintTextStyle,
+                            hintStyle:AppTextStyles.hint,
                             contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12), // 중앙 정렬
                           ),
                           textAlignVertical: TextAlignVertical.center, // 텍스트 수직 중앙 정렬
@@ -200,7 +170,7 @@ class JoinMembershipScreen3 extends StatelessWidget {
                     ),
                     child: Text(
                       '이전',
-                      style: hintTextStyle.copyWith(
+                      style: AppTextStyles.hint.copyWith(
                         color: Colors.black,
                         fontSize: 14,
                       ),
@@ -220,7 +190,7 @@ class JoinMembershipScreen3 extends StatelessWidget {
                     ),
                     child: Text(
                       '다음',
-                      style: buttonTextStyle,
+                      style:AppTextStyles.button,
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lyc_flutter_project/lib/screens/login_screen.dart
+++ b/lyc_flutter_project/lib/screens/login_screen.dart
@@ -1,54 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:lyc_flutter_project/data/app_color.dart';
 import 'package:lyc_flutter_project/screens/join_membership_screen_1.dart';
+import '../widget/AppTextStyles.dart';
 
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-// 공통 TextStyle
-    TextStyle titleTextStyle = TextStyle(
-      fontWeight: FontWeight.w700,
-      fontSize: 20,
-      letterSpacing: -0.1,
-      color: Colors.white,
-    );
-
-    TextStyle labelTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: Color(0xFF000000),
-    );
-
-    TextStyle hintTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: Color(0xFF8D8D8D),
-    );
-
-    TextStyle linkTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 10,
-      decoration: TextDecoration.underline,
-      height: 1,
-      letterSpacing: -0.1,
-      color: Color(0xFF000000),
-      decorationColor: Color(0xFF000000),
-    );
-
-    TextStyle otherLoginTextStyle = TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 12,
-      height: 1.5,
-      letterSpacing: -0.1,
-      color: Color(0xFF718096),
-    );
-
     return Scaffold(
       backgroundColor: AppColor.lightGrey,
       appBar: AppBar(
@@ -62,19 +21,18 @@ class LoginScreen extends StatelessWidget {
             children: [
               Text(
                 '대충 로고',
-                style: titleTextStyle,
+                style: AppTextStyles.title,
                 textAlign: TextAlign.center,
               ),
               Text(
                 '유클리드 소개',
-                style: titleTextStyle,
+                style: AppTextStyles.title,
                 textAlign: TextAlign.center,
               ),
             ],
           ),
         ),
       ),
-
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -102,7 +60,7 @@ class LoginScreen extends StatelessWidget {
                             alignment: Alignment.topLeft,
                             child: Text(
                               '아이디',
-                              style: labelTextStyle,
+                              style: AppTextStyles.labelTextStyle,
                             ),
                           ),
                         ),
@@ -117,7 +75,7 @@ class LoginScreen extends StatelessWidget {
                               decoration: InputDecoration(
                                 border: InputBorder.none,
                                 hintText: '아이디를 입력해주세요',
-                                hintStyle: hintTextStyle,
+                                hintStyle: AppTextStyles.hint,
                               ),
                             ),
                           ),
@@ -137,7 +95,7 @@ class LoginScreen extends StatelessWidget {
                             alignment: Alignment.topLeft,
                             child: Text(
                               '패스워드',
-                              style: labelTextStyle,
+                              style: AppTextStyles.labelTextStyle,
                             ),
                           ),
                         ),
@@ -153,7 +111,7 @@ class LoginScreen extends StatelessWidget {
                               decoration: InputDecoration(
                                 border: InputBorder.none,
                                 hintText: '패스워드를 입력해주세요',
-                                hintStyle: hintTextStyle,
+                                hintStyle: AppTextStyles.hint,
                               ),
                             ),
                           ),
@@ -174,29 +132,29 @@ class LoginScreen extends StatelessWidget {
                                 context,
                                 MaterialPageRoute(builder: (context) => const JoinMembershipScreen1()),
                               );
-// 회원가입 버튼 눌렀을 때의 동작 구현
+                              // 회원가입 버튼 눌렀을 때의 동작 구현
                             },
                             child: Text(
                               '회원가입',
-                              style: linkTextStyle,
+                              style: AppTextStyles.linkTextStyle,
                             ),
                           ),
                           TextButton(
                             onPressed: () {
-// 아이디찾기 버튼 눌렀을 때의 동작 구현
+                              // 아이디찾기 버튼 눌렀을 때의 동작 구현
                             },
                             child: Text(
                               '아이디찾기',
-                              style: linkTextStyle,
+                              style: AppTextStyles.linkTextStyle,
                             ),
                           ),
                           TextButton(
                             onPressed: () {
-// 비밀번호찾기 버튼 눌렀을 때의 동작 구현
+                              // 비밀번호찾기 버튼 눌렀을 때의 동작 구현
                             },
                             child: Text(
                               '비밀번호찾기',
-                              style: linkTextStyle,
+                              style: AppTextStyles.linkTextStyle,
                             ),
                           ),
                         ],
@@ -235,7 +193,7 @@ class LoginScreen extends StatelessWidget {
                   ),
                   TextButton(
                     onPressed: () {
-// 로그인 버튼 눌렀을 때의 동작 구현
+                      // 로그인 버튼 눌렀을 때의 동작 구현
                     },
                     style: TextButton.styleFrom(
                       backgroundColor: AppColor.beige,
@@ -248,13 +206,7 @@ class LoginScreen extends StatelessWidget {
                       width: 230,
                       child: Text(
                         '로그인',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w700,
-                          fontSize: 14,
-                          height: 1.3,
-                          letterSpacing: -0.1,
-                          color: Colors.white,
-                        ),
+                        style: AppTextStyles.button,
                         textAlign: TextAlign.center,
                       ),
                     ),
@@ -264,11 +216,11 @@ class LoginScreen extends StatelessWidget {
             ),
             TextButton(
               onPressed: () {
-// 다른 계정으로 로그인 버튼 눌렀을 때의 동작 구현
+                // 다른 계정으로 로그인 버튼 눌렀을 때의 동작 구현
               },
               child: Text(
                 '다른 계정으로 로그인',
-                style: otherLoginTextStyle,
+                style: AppTextStyles.otherLoginTextStyle,
               ),
             ),
             SizedBox(
@@ -283,7 +235,7 @@ class LoginScreen extends StatelessWidget {
                       height: 35,
                     ),
                     onPressed: () {
-// 네이버 로그인 버튼 눌렀을 때의 동작 구현
+                      // 네이버 로그인 버튼 눌렀을 때의 동작 구현
                     },
                   ),
                   IconButton(
@@ -293,7 +245,7 @@ class LoginScreen extends StatelessWidget {
                       height: 35,
                     ),
                     onPressed: () {
-// 카카오톡 로그인 버튼 눌렀을 때의 동작 구현
+                      // 카카오톡 로그인 버튼 눌렀을 때의 동작 구현
                     },
                   ),
                   IconButton(
@@ -303,7 +255,7 @@ class LoginScreen extends StatelessWidget {
                       height: 35,
                     ),
                     onPressed: () {
-// 구글 로그인 버튼 눌렀을 때의 동작 구현
+                      // 구글 로그인 버튼 눌렀을 때의 동작 구현
                     },
                   ),
                 ],

--- a/lyc_flutter_project/lib/widget/AppTextStyles.dart
+++ b/lyc_flutter_project/lib/widget/AppTextStyles.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:lyc_flutter_project/data/app_color.dart';
+
+class AppTextStyles {
+  static const TextStyle title = TextStyle(
+    fontWeight: FontWeight.w700,
+    fontSize: 20,
+    letterSpacing: -0.1,
+    color: Colors.white,
+  );
+
+  static const TextStyle hint = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 12,
+    height: 1.5,
+    letterSpacing: -0.1,
+    color: AppColor.deepGrey,
+  );
+
+  static const TextStyle littleTitle = TextStyle(
+    fontWeight: FontWeight.w700,
+    fontSize: 16,
+    height: 1.1,
+    letterSpacing: -0.1,
+    color: Colors.black,
+  );
+
+  static const TextStyle button = TextStyle(
+    fontWeight: FontWeight.w700,
+    fontSize: 14,
+    height: 1.3,
+    letterSpacing: -0.1,
+    color: Colors.white,
+  );
+
+  static const TextStyle labelTextStyle = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 12,
+    height: 1.5,
+    letterSpacing: -0.1,
+    color: Colors.black,
+  );
+
+  static const TextStyle linkTextStyle = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 10,
+    decoration: TextDecoration.underline,
+    height: 1,
+    letterSpacing: -0.1,
+    color: Colors.black,
+    decorationColor: Colors.black,
+  );
+
+  static const TextStyle otherLoginTextStyle = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 12,
+    height: 1.5,
+    letterSpacing: -0.1,
+    color: Color(0xFF718096),
+  );
+}


### PR DESCRIPTION
# 📌 Pull Request
> **30**
### Works
* text style 위젯 분리
* 회원가입 페이지, 로그인 페이지 refactoring
* 같은 TextStyle을 쓰는 화면이 있다면 refactoring하는 게 좋을 것 같습니다

***

Pull Request 요청자
|---|
|<div align="center"><img src="https://contrib.rocks/image?repo={s1hwa}/{lyc-frontend_dvlp_sh}" /></div>|
|<div align="center">{s1hwa}</div>|
